### PR TITLE
update to 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
 	id 'fabric-loom' version '0.12.+'
 	id 'io.github.juuxel.loom-quiltflower' version '1.+'
-	id 'org.quiltmc.quilt-mappings-on-loom' version '4.+'
 }
 
 repositories {
@@ -24,9 +23,7 @@ group = project.maven_group
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings(loom.layered {
-		addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${project.minecraft_version}+build.${project.mappings_version}:v2"))
-	})
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 
 	modImplementation "net.fabricmc:fabric-loader:${project.fabric_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fapi_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,21 +2,22 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 1.1.0
+mod_version = 2.0.0
 maven_group= me.benfah
 archives_base_name = doorsofinfinity
 
 # Mod defs
 # MC Versions & Mapping Versions
-minecraft_version = 1.19
-mappings_version = 1
+minecraft_version = 1.19.2
+yarn_mappings=1.19.2+build.14
 
 # Api Versions
-fapi_version = 0.55.1+1.19
+fapi_version = 0.61.0+1.19.2
 
 # Loader Versions
-fabric_version = 0.14.7
+fabric_version = 0.14.9
 
 midnightlib_version=0.5.2
 modmenu_version=4.0.0
-imm_ptl_version=2.0.1-1.19
+imm_ptl_version=v2.2.3-1.19.2
+

--- a/src/main/java/me/benfah/doorsofinfinity/block/entity/InfinityDoorBlockEntity.java
+++ b/src/main/java/me/benfah/doorsofinfinity/block/entity/InfinityDoorBlockEntity.java
@@ -87,11 +87,11 @@ public class InfinityDoorBlockEntity extends AbstractInfinityDoorBlockEntity<Inf
 	}
 
 	public BlockEntityUpdateS2CPacket toUpdatePacket() {
-		return BlockEntityUpdateS2CPacket.of(this);
+		return BlockEntityUpdateS2CPacket.create(this);
 	}
 
 	public NbtCompound toInitialChunkDataNbt() {
-		return this.toNbt();
+		return this.createNbt();
 	}
 
 	public void markDirty() {

--- a/src/main/java/me/benfah/doorsofinfinity/chunkgen/EmptyChunkGenerator.java
+++ b/src/main/java/me/benfah/doorsofinfinity/chunkgen/EmptyChunkGenerator.java
@@ -9,7 +9,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.structure.StructureManager;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.world.*;
@@ -18,7 +17,8 @@ import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.gen.GenerationStep;
-import net.minecraft.world.gen.RandomState;
+import net.minecraft.world.gen.noise.NoiseConfig;
+import net.minecraft.world.gen.StructureAccessor;
 import net.minecraft.world.gen.chunk.Blender;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.chunk.VerticalBlockSample;
@@ -39,10 +39,10 @@ public class EmptyChunkGenerator extends ChunkGenerator {
 	}
 
 	@Override
-	public void carve(ChunkRegion chunkRegion, long seed, RandomState randomState, BiomeAccess biomeAccess, StructureManager structureManager, Chunk chunk, GenerationStep.Carver generationStep) {}
+	public void carve(ChunkRegion chunkRegion, long seed, NoiseConfig noiseconfig, BiomeAccess biomeAccess, StructureAccessor structureAccessor, Chunk chunk, GenerationStep.Carver generationStep) {}
 
 	@Override
-	public void buildSurface(ChunkRegion region, StructureManager structureManager, RandomState randomState, Chunk chunk) {}
+	public void buildSurface(ChunkRegion region, StructureAccessor structures, NoiseConfig noiseconfig, Chunk chunk) {}	
 
 	@Override
 	public void populateEntities(ChunkRegion region) {}
@@ -53,10 +53,9 @@ public class EmptyChunkGenerator extends ChunkGenerator {
 	}
 
 	@Override
-	public CompletableFuture<Chunk> populateNoise(Executor executor, Blender blender, RandomState randomState, StructureManager structureManager, Chunk chunk) {
+	public CompletableFuture<Chunk> populateNoise(Executor executor, Blender blender,NoiseConfig noiseconfig, StructureAccessor structureAccessor, Chunk chunk) {
 		return CompletableFuture.completedFuture(chunk);
 	}
-
 	@Override
 	public int getSeaLevel() {
 		return 0;
@@ -68,15 +67,15 @@ public class EmptyChunkGenerator extends ChunkGenerator {
 	}
 
 	@Override
-	public int getHeight(int x, int z, Type heightmap, HeightLimitView world, RandomState randomState) {
+	public int getHeight(int x, int z, Type heightmap, HeightLimitView world, NoiseConfig noiseconfig) {
 		return 256;
 	}
 
 	@Override
-	public VerticalBlockSample getColumnSample(int x, int z, HeightLimitView world, RandomState randomState) {
-		return new VerticalBlockSample(0, new BlockState[0]);
+	public VerticalBlockSample getColumnSample(int x, int z, HeightLimitView world, NoiseConfig noiseconfig) {
+		return new VerticalBlockSample(world.getBottomY(), new BlockState[0]);
 	}
 
 	@Override
-	public void method_40450(List<String> list, RandomState randomState, BlockPos blockPos) {}
+	public void getDebugHudText(List<String> list, NoiseConfig noiseconfig, BlockPos blockPos) {}
 }

--- a/src/main/java/me/benfah/doorsofinfinity/mixin/MinecraftServerMixin.java
+++ b/src/main/java/me/benfah/doorsofinfinity/mixin/MinecraftServerMixin.java
@@ -4,13 +4,14 @@ import com.mojang.authlib.GameProfileRepository;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
 import com.mojang.datafixers.DataFixer;
 import me.benfah.doorsofinfinity.utils.MCUtils;
-import net.minecraft.resource.pack.ResourcePackManager;
+import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.Services;
+import net.minecraft.server.SaveLoader;
 import net.minecraft.server.WorldGenerationProgressListenerFactory;
-import net.minecraft.server.WorldStem;
 import net.minecraft.util.UserCache;
 import net.minecraft.world.level.storage.LevelStorage;
+import net.minecraft.util.ApiServices;
+import net.minecraft.world.SaveProperties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,7 +23,11 @@ import java.net.Proxy;
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
     @Inject(method = "<init>", at = @At(value = "RETURN"))
-    public void doorsOfInfinity$onInit(Thread thread, LevelStorage.Session session, ResourcePackManager resourcePackManager, WorldStem worldStem, Proxy proxy, DataFixer dataFixer, Services services, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory, CallbackInfo ci) {
+    public void doorsOfInfinity$onInit(Thread thread, LevelStorage.Session session, 
+        ResourcePackManager resourcePackManager, SaveLoader saveLoader, Proxy proxy, 
+        DataFixer dataFixer, ApiServices apiServices,
+        WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory, 
+        CallbackInfo ci) {
         MCUtils.mcServerReference = new WeakReference<>((MinecraftServer) ((Object) this));
     }
 }


### PR DESCRIPTION
Initial port to 1.19.2. No new functionality. I did not test it for 1.19 or 1.19.1. I also did not test the Photon Transmitter function. Just the dimension.